### PR TITLE
Change the url for macOS's build repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 * [地图画原理](github.com/ToKiNoBug/SlopeCraftTutorial/tree/main/BasicPrinciple)
 
 # 其他平台上的发行版
-* [SlopeCraft for Linux macOS](https://github.com/HMUniversity/SlopeCraft-for-Linux-macOS) Linux和MacOS上的适配和release
+* [SlopeCraft for macOS](https://github.com/iXORTech/SlopeCraft-for-macOS) - macOS 操作系统的适配与构建
 
 # 使用教程
 
@@ -109,10 +109,10 @@ SlopeCraft包含以下核心功能：
 
 
 # 其他相关仓库
-* [NBTWriter](https://github.com/ToKiNoBug/NBTWriter-of-Toki) 写NBT文件的库（自己写的，功能比较弱，满足自己的需求就够了）
-* [SlopeCraftTutorial](https://github.com/ToKiNoBug/SlopeCraftTutorial) 专门存放教程
-* [SlopeCraftCompressLib](https://github.com/ToKiNoBug/SlopeCraftCompressLib) 无损压缩库，也承担了构建高度矩阵的功能
-* [SlopeCraftLossyCompression](https://github.com/ToKiNoBug/SlopeCraftLossyCompression) 有损压缩库，基于无损压缩库实现
-* [SlopeCraftGlassBuilder](https://github.com/ToKiNoBug/SlopeCraftGlassBuilder) 搭桥库
-* [HeuristicFlow](https://github.com/TokiNoBug/HeuristicFlow) 遗传算法实现
-* [SlopeCraft for Linux macOS](https://github.com/HMUniversity/SlopeCraft-for-Linux-macOS) Linux和MacOS上的适配和releases
+* [NBTWriter](https://github.com/ToKiNoBug/NBTWriter-of-Toki) - 写NBT文件的库（自己写的，功能比较弱，满足自己的需求就够了）
+* [SlopeCraftTutorial](https://github.com/ToKiNoBug/SlopeCraftTutorial) - 专门存放教程
+* [SlopeCraftCompressLib](https://github.com/ToKiNoBug/SlopeCraftCompressLib) - 无损压缩库，也承担了构建高度矩阵的功能
+* [SlopeCraftLossyCompression](https://github.com/ToKiNoBug/SlopeCraftLossyCompression) - 有损压缩库，基于无损压缩库实现
+* [SlopeCraftGlassBuilder](https://github.com/ToKiNoBug/SlopeCraftGlassBuilder) - 搭桥库
+* [HeuristicFlow](https://github.com/TokiNoBug/HeuristicFlow) - 遗传算法实现
+* [SlopeCraft for macOS](https://github.com/iXORTech/SlopeCraft-for-macOS) - macOS 操作系统的适配与构建

--- a/README_EN.md
+++ b/README_EN.md
@@ -17,8 +17,8 @@
 # Principles
 * [Pinciple of Map Pixel Arts](https://github.com/ToKiNoBug/SlopeCraftTutorial/blob/main/en_US/BasicPrinciple/README.md)
 
-# For Other Platforms
-* [SlopeCraft for Linux macOS](https://github.com/HMUniversity/SlopeCraft-for-Linux-macOS) Adpative and releases for Linux and MacOS.
+# Builds for Other Platforms
+* [SlopeCraft for macOS](https://github.com/iXORTech/SlopeCraft-for-macOS) - Compatibility changes and builds for macOS
 
 # Tutorials:
 
@@ -100,10 +100,10 @@ No Installation Required
 See tutorials listed above.
 
 # Other Related Repos
-* [NBTWriter](https://github.com/ToKiNoBug/NBTWriter-of-Toki) A lib to write nbt files.
-* [SlopeCraftTutorial](https://github.com/ToKiNoBug/SlopeCraftTutorial) Tutorials
-* [SlopeCraftCompressLib](https://github.com/ToKiNoBug/SlopeCraftCompressLib) Lib for building height map and lossless compression lib.
-* [SlopeCraftLossyCompression](https://github.com/ToKiNoBug/SlopeCraftLossyCompression) Lossy compression lib, based on SlopeCraftCompressLib.
-* [SlopeCraftGlassBuilder](https://github.com/ToKiNoBug/SlopeCraftGlassBuilder) Glass bridge building lib.
-* [HeuristicFlow](https://github.com/TokiNoBug/HeuristicFlow) GA implementation.
-* [SlopeCraft for Linux macOS](https://github.com/HMUniversity/SlopeCraft-for-Linux-macOS) Adpative and releases for Linux and MacOS.
+* [NBTWriter](https://github.com/ToKiNoBug/NBTWriter-of-Toki) - Lib for writing NBT files.
+* [SlopeCraftTutorial](https://github.com/ToKiNoBug/SlopeCraftTutorial) - Tutorials
+* [SlopeCraftCompressLib](https://github.com/ToKiNoBug/SlopeCraftCompressLib) - Lib for building height map and lossless compression lib.
+* [SlopeCraftLossyCompression](https://github.com/ToKiNoBug/SlopeCraftLossyCompression) - Lossy compression lib, based on SlopeCraftCompressLib.
+* [SlopeCraftGlassBuilder](https://github.com/ToKiNoBug/SlopeCraftGlassBuilder) - Glass bridge building lib.
+* [HeuristicFlow](https://github.com/TokiNoBug/HeuristicFlow) - GA implementation.
+* [SlopeCraft for macOS](https://github.com/iXORTech/SlopeCraft-for-macOS) - Compatibility changes and builds for macOS


### PR DESCRIPTION
更改了一下 macOS 构建的仓库链接，这是跨平台 repo 规划的一部分，目前暂时移除了 Linux 是因为 67au 比较忙，而我的 Linux 环境暂时也还没有被搭建起来，所以暂时移除掉一段时间，可以发布之后我会再提交新的 Pull Request。