### PR TITLE
chore: Ignore `.DS_Store` in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
-
 *.idx
 compile_commands.json
 *.qm
 CMakeLists.txt.user
+
+# macOS File System
+.DS_Store


### PR DESCRIPTION
Add `.DS_Store` file generated by macOS File System to `.gitignore`.

This change is done for improving workflow under multiple operating systems. Please merge this and bring it to the `main` branch **A.S.A.P.**